### PR TITLE
Fix typo: "rest"->"reset"

### DIFF
--- a/GitUI/UI/PendingChanges.xaml
+++ b/GitUI/UI/PendingChanges.xaml
@@ -84,7 +84,7 @@
                     <Button Content="Stage Selected" Padding="10 0"
                                     Name="btnStageSelected" 
                                     VerticalAlignment="Center" Margin="0,0,4,0" Click="btnStageSelected_Click"/>
-                    <Button Content="Rest File" Padding="10 0"
+                    <Button Content="Reset File" Padding="10 0"
                                     Name="btnResetFile" 
                                     VerticalAlignment="Center" Margin="0,0,4,0" Click="btnResetFile_Click"/>
                     <Button Content="Reset Selected" Padding="10 0"

--- a/VsGitToolsPackage/MyControl.xaml
+++ b/VsGitToolsPackage/MyControl.xaml
@@ -446,7 +446,7 @@
                                     Name="btnStageSelected" Foreground="{DynamicResource {x:Static vsfx:VsBrushes.ToolWindowTextKey}}" 
                                     Background="{DynamicResource {x:Static vsfx:VsBrushes.ToolWindowBackgroundKey}}"
                                     VerticalAlignment="Center" Margin="0,0,4,0" Click="btnStageSelected_Click"/>
-                            <Button Content="Rest File" Padding="10 0"
+                            <Button Content="Reset File" Padding="10 0"
                                     Name="btnResetFile" Foreground="{DynamicResource {x:Static vsfx:VsBrushes.ToolWindowTextKey}}" 
                                     Background="{DynamicResource {x:Static vsfx:VsBrushes.ToolWindowBackgroundKey}}"
                                     VerticalAlignment="Center" Margin="0,0,4,0" Click="btnResetFile_Click"/>


### PR DESCRIPTION
Inspired after I discovered this "Rest" UI typo:

![image](https://user-images.githubusercontent.com/278006/34175381-e2ee376c-e4c1-11e7-8b8b-09cfcbcc9694.png)